### PR TITLE
Prevent buffer overflow in retransmission. Improve WiFi begin connection

### DIFF
--- a/src/Fossa_GroundStation/Fossa_GroundStation.ino
+++ b/src/Fossa_GroundStation/Fossa_GroundStation.ino
@@ -1290,12 +1290,12 @@ void requestPacketInfo() {
 
 void requestRetransmit() {
   Serial.println(F("Enter message to be sent:"));
-  Serial.println(F("(max 32 characters, end with LF or CR+LF)"));
+  Serial.println(F("(max 30 characters, end with LF or CR+LF)"));
 
   // get data to be retransmited
   char optData[32];
   uint8_t bufferPos = 0;
-  while(bufferPos < 32) {
+  while(bufferPos < 31) {
     while(!Serial.available());
     char c = Serial.read();
     Serial.print(c);

--- a/src/Fossa_GroundStation/config_manager.cpp
+++ b/src/Fossa_GroundStation/config_manager.cpp
@@ -35,10 +35,12 @@ bool Config_managerClass::begin(bool invalidate_config)
 		ESP_LOGI (WIFIMAN_TAG, "Configuration loaded from flash");
 		if (invalidate_config)
 			WiFi.begin ("0"); // Reset Wifi credentials
-		else
+		else{
+			WiFi.enableSTA(true);
 			WiFi.begin (board_config->ssid, board_config->pass);
+		}
 		unsigned long start_connect = millis ();
-		while (millis () - start_connect > WIFI_CONNECT_TIMEOUT) {
+		while (millis () - start_connect < WIFI_CONNECT_TIMEOUT) {
 			Serial.print ('.');
 			delay (250);
 		}


### PR DESCRIPTION
Re-transmit a buffer or 32 chars crashes the Groundstation. Limit the input size (or increase the buffer by 1 to make space for the \0, termination)

Lolin32 dev have issues with WiFi connections, a solution suggested generally for ESP32 is to add a WiFi.enableSTA before wifi.begin. Seems to improve the begin connection. Not prefect.

Wait did not happen as test was wrong. It may be necessary to change wait time to 3 seconds instead of 10. 