### PR TITLE
Change Var Type for "NORAD" to allow for ID #'s greater than 65535

### DIFF
--- a/FossaGroundStation/src/Radio/Radio.cpp
+++ b/FossaGroundStation/src/Radio/Radio.cpp
@@ -1050,7 +1050,7 @@ void Radio::remote_sat(char* payload, size_t payload_len) {
   payloadStr[payload_len] = '\0';
   deserializeJson(doc, payload);
   const char* satellite = doc[0];
-  uint16_t  NORAD     =  doc[1];
+  uint32_t  NORAD     =  doc[1];
   status.modeminfo.NORAD = NORAD;
   String str(satellite);
   status.modeminfo.satellite = str;

--- a/FossaGroundStation/src/Status.h
+++ b/FossaGroundStation/src/Status.h
@@ -59,7 +59,7 @@ struct ModemInfo {
   int     dataShaping = 0;    // 0 disable  1 -> 0.3  2-> 0.5  3 -> 0.6  4-> 1.0
   bool    crc         = true;
   byte    fldro       = true;
-  uint16_t  NORAD     = 46494;  // funny this remember me WARGames
+  uint32_t  NORAD     = 46494;  // funny this remember me WARGames
 
 };
 


### PR DESCRIPTION
Changed "NORAD" type to uint32_t to allow for numbers greater than 65535 such as the 9xxxx temporary ID numbers